### PR TITLE
Create basic configuration and info files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Basic .gitattributes for a python repo.
+
+# Source files
+# ============
+*.pxd        text
+*.py         text
+*.py3         text
+*.pyw         text
+*.pyx          text
+
+# Binary files
+# ============
+*.db        binary
+*.p         binary
+*.pkl         binary
+*.pyc         binary
+*.pyd        binary
+*.pyo         binary
+
+# Note: .db, .p, and .pkl files are associated
+# with the python modules ``pickle``, ``dbm.*``,
+# ``shelve``, ``marshal``, ``anydbm``, & ``bsddb``
+# (among others).

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,21 +1,21 @@
 # Basic .gitattributes for a python repo.
 
 # Source files
-# ============
-*.pxd        text
-*.py         text
-*.py3         text
-*.pyw         text
-*.pyx          text
+# =================
+*.pxd       text
+*.py        text
+*.py3       text
+*.pyw       text
+*.pyx       text
 
 # Binary files
-# ============
+# =================
 *.db        binary
 *.p         binary
-*.pkl         binary
-*.pyc         binary
-*.pyd        binary
-*.pyo         binary
+*.pkl       binary
+*.pyc       binary
+*.pyd       binary
+*.pyo       binary
 
 # Note: .db, .p, and .pkl files are associated
 # with the python modules ``pickle``, ``dbm.*``,

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,98 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 *.pyc
-__pycache__
-myvenv
-db.sqlite3
-/static
 .DS_Store
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+/static
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+myvenv
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Database
+db.sqlite3

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of Volodymyr Pavlenko nor the names of its
+* Neither the name of DjangoGirls Blog nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-**Copyright &copy; 2016, Kpi-Web-Guild**
+**Copyright &copy; 2016, Volodymyr Pavlenko**
 
 **All rights reserved.**
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,30 @@
+**Copyright &copy; 2016, Kpi-Web-Guild**
+
+**All rights reserved.**
+
+* * *
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Kpi-Web-Guild nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of Kpi-Web-Guild nor the names of its
+* Neither the name of Volodymyr Pavlenko nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+[![Build Status](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0.png)](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0)
+# My Django Blog
+
+With the help of the [DjangoGirls](https://www.gitbook.com/book/djangogirls/djangogirls-tutorial/details) I create my own blog.
+
+## Additional information
+
+To find and fix common issues before running I use different hooks from [pre-commit](http://pre-commit.com/). To test the project I use the [Travis CI](https://travis-ci.org/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0.png)](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0)
+[![Build Status](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0.svg?branch=master)](https://travis-ci.org/kpi-web-guild/django-girls-blog-pavlenk0)
 # My Django Blog
 
 With the help of the [DjangoGirls](https://www.gitbook.com/book/djangogirls/djangogirls-tutorial/details) I create my own blog.


### PR DESCRIPTION
Create new files for basic configuration:
README.md is used to generate the html summary you see at the bottom of projects.
LICENSE.md is used to retain all rights to your source code and that nobody else may reproduce, distribute, or create derivative works from your work.
.gitattributes is a simple text file that gives attributes to pathnames.
Create the template of .gitignore file, which have been created earlier.